### PR TITLE
add support of onTouchMove to TouchableMixin

### DIFF
--- a/src/js/Touchable.js
+++ b/src/js/Touchable.js
@@ -13,7 +13,7 @@ import React from 'react';
 import TouchableMixin from './mixins/TouchableMixin';
 import createChainedFunction from './utils/createChainedFunction';
 import supportTouch from './utils/isTouchSupported';
-import './utils/UCUIController';
+import './utils/ucUIControl';
 
 const Touchable = React.createClass({
   mixins: [TouchableMixin],

--- a/src/js/mixins/TouchableMixin.js
+++ b/src/js/mixins/TouchableMixin.js
@@ -103,9 +103,15 @@ let TouchableMixin = {
       startTouch,
       endTouch: lastTouch,
     } = this.state;
+
+    let deltaX, deltaY;
     lastTouch = lastTouch || startTouch;
-    let deltaX = endTouch.pageX - lastTouch.pageX;
-    let deltaY = endTouch.pageY - lastTouch.pageY;
+    if (lastTouch) {
+      deltaX = endTouch.pageX - lastTouch.pageX;
+      deltaY = endTouch.pageY - lastTouch.pageY;
+    } else {
+      deltaX = deltaY = 0;
+    }
 
     this._cancelPress();
 


### PR DESCRIPTION
原代码将deltaX, deltaY记录在Touchable.state中，分别表示在触摸事件中，从TouchStart起 X和Y 总共移动了的绝对值距离之和。我觉得这个变量名有歧义，将其改写成 state.touch.deltaXSum。

state.deltaX 改写为用来记录最后一次触摸事件中X移动的相对距离（有正负），并使Touchable支持onTouchMove prop。它可以用来支持“拖动”事件，例如 http://m.toutiao.com/ 顶部的可拖动标签栏。

如果觉得修改deltaX, deltaY的含义会导致不兼容，我可以修改一下 保留deltaX, deltaY，用lastDeltaX之类的名字来表示最后一次触摸事件的位置变化。但deltaX在原代码中真的比较有歧义，建议还是把它改掉

另外，deltaXSum （原来的deltaX) 的唯一用途是：

    // don't fire tap when delta position changed by more than 30 
    // for instance when moving to a point and back to origin
    if (deltaX < moveThreshold && deltaY < moveThreshold)

我觉得相比于 “从TouchStart起 每次触摸事件移动距离的绝对值之和”， 用 “从TouchStart起 离开起始点的最远距离” 为判断依据可能更合理。（这个建议没有加入到pull request中）